### PR TITLE
Add releases section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,17 @@ A separate Python installation is recommended if you need a full-blown Python fo
 For other installation methods,
 see Toolbox [installation](https://github.com/spine-tools/Spine-Toolbox?tab=readme-ov-file#installation).
 
-### Development snapshots
+### Releases
 
 Consider taking backups of your projects and Spine databases if you are upgrading from version 0.7.x.
 
+#### Latest
+
+- [Spine-Toolbox-win-0.8.1.zip](https://github.com/spine-tools/Spine-Toolbox/releases/download/0.8.1/Spine-Toolbox-win-0.8.1.zip) (2024-05-14)
+
+### Development snapshots
+
+- [Spine Toolbox 0.8.1.zip](https://github.com/spine-tools/Spine-Toolbox/actions/runs/9091217350/artifacts/1503996289) (2024-05-15)
 - [Spine Toolbox 0.9.0.dev20+gc291307c.zip](https://github.com/spine-tools/Spine-Toolbox/actions/runs/9076990372/artifacts/1500451137) (2024-05-14)
 - [Spine Toolbox 0.9.0.dev11+g08faff31.zip](https://github.com/spine-tools/Spine-Toolbox/actions/runs/8982971897/artifacts/1479608877) (2024-05-07)
 - [Spine Toolbox 0.8.0.zip](https://github.com/spine-tools/Spine-Toolbox/actions/runs/8892474721/artifacts/1459890009) (2024-04-30)

--- a/generate_readme.py
+++ b/generate_readme.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import logging
 from operator import attrgetter
+from typing import Union
 
 import mdutils
 import requests
@@ -13,6 +14,11 @@ MAX_ARTIFACTS = 10
 logging.basicConfig()
 logger = logging.getLogger(__name__)
 
+headers = {
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28"
+}
+
 
 @dataclass
 class Artifact:
@@ -20,13 +26,24 @@ class Artifact:
     download_url: str
     created_at: datetime
 
+    def md_link(self) -> str:
+        label = f"{self.name}.zip"
+        return mdutils.tools.Link.Inline.new_link(self.download_url, label)
+
+
+@dataclass
+class ReleaseAsset:
+    version: str
+    name: str
+    download_url: str
+    created_at: datetime
+
+    def md_link(self) -> str:
+        return mdutils.tools.Link.Inline.new_link(self.download_url, self.name)
+
 
 def request_artifacts() -> list[Artifact]:
     artifacts: list[Artifact] = []
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28"
-    }
     current_url = "https://api.github.com/repos/spine-tools/Spine-Toolbox/actions/artifacts"
     while current_url is not None and len(artifacts) < MAX_ARTIFACTS:
         raw_response = requests.get(current_url, headers=headers)
@@ -60,19 +77,39 @@ def request_artifacts() -> list[Artifact]:
     return artifacts
 
 
-def build_link(artifact: Artifact) -> str:
-    label = f"{artifact.name}.zip"
-    return mdutils.tools.Link.Inline.new_link(artifact.download_url, label)
+def build_link_list_items(items: list[Union[Artifact, ReleaseAsset]]) -> list[str]:
+    link_items: list[str] = []
+    for item in items:
+        link_items.append(f"{item.md_link()} ({item.created_at.strftime("%Y-%m-%d")})")
+    return link_items
 
 
-def build_link_list_items(artifacts: list[Artifact]) -> list[str]:
-    items = []
-    for artifact in artifacts:
-        items.append(f"{build_link(artifact)} ({artifact.created_at.strftime("%Y-%m-%d")})")
-    return items
+snapshot_link_items = build_link_list_items(request_artifacts())
 
 
-link_items = build_link_list_items(request_artifacts())
+def request_release_assets() -> list[ReleaseAsset]:
+    assets: list[ReleaseAsset] = []
+    url = "https://api.github.com/repos/spine-tools/Spine-Toolbox/releases"
+    raw_response = requests.get(url, headers=headers)
+    response = raw_response.json()
+    for release in response:
+        created_at = datetime.fromisoformat(release["published_at"])
+        if created_at < datetime(year=2024, month=5, day=1, tzinfo=created_at.tzinfo):
+            # The installers before the 0.8 bundles are not recommended for users.
+            continue
+        version = release["tag_name"]
+        assets_url = release["assets_url"]
+        assets_raw_response = requests.get(assets_url, headers=headers)
+        assets_response = assets_raw_response.json()
+        for asset in assets_response:
+            name = asset["name"]
+            download_url = asset["browser_download_url"]
+            assets.append(ReleaseAsset(version, name, download_url, created_at))
+    return sorted(assets, key=attrgetter("created_at"), reverse=True)
+
+
+release_link_items = build_link_list_items(request_release_assets())
+
 readme = mdutils.MdUtils(file_name="README.md", title="Downloads")
 readme.new_header(level=1, title="Spine Toolbox")
 readme.new_header(level=2, title="Relocatable bundles for Windows")
@@ -96,11 +133,17 @@ For other installation methods,
 see Toolbox [installation](https://github.com/spine-tools/Spine-Toolbox?tab=readme-ov-file#installation).
 """
 )
-readme.new_header(level=3, title="Development snapshots")
+readme.new_header(level=3, title="Releases")
 readme.write(
 """
 Consider taking backups of your projects and Spine databases if you are upgrading from version 0.7.x.
 """
 )
-readme.new_list(link_items)
+readme.new_header(level=4, title="Latest")
+readme.new_list([release_link_items[0]])
+if len(release_link_items) > 1:
+    readme.new_header(level=4, title="Older releases")
+    readme.new_list(release_link_items[1:])
+readme.new_header(level=3, title="Development snapshots")
+readme.new_list(snapshot_link_items)
 readme.create_md_file()


### PR DESCRIPTION
This PR adds new functionality to the `generate_readme.py` script that fetches release assets from Spine-Toolbox repository and adds release bundles that are newer than 2024-05-01 (>= 0.8) to a new "Releases" section in `README.md`.